### PR TITLE
Drop categories from metainfo.xml

### DIFF
--- a/io.github.huderlem.porymap.metainfo.xml
+++ b/io.github.huderlem.porymap.metainfo.xml
@@ -493,23 +493,10 @@
   <url type="homepage">https://huderlem.github.io/porymap</url>
   <url type="bugtracker">https://github.com/huderlem/porymap/issues</url>
   <url type="vcs-browser">https://github.com/huderlem/porymap</url>
-  <categories>
-    <category>Game</category>
-    <category>Utility</category>
-    <category>Qt</category>
-  </categories>
   <recommends>
     <control>pointing</control>
     <control>keyboard</control>
   </recommends>
   <content_rating type="oars-1.1"/>
   <launchable type="desktop-id">io.github.huderlem.porymap.desktop</launchable>
-  <keywords>
-    <keyword>Nintendo</keyword>
-    <keyword>Pokemon</keyword>
-    <keyword>GameBoy</keyword>
-    <keyword>GBA</keyword>
-    <keyword>Hack</keyword>
-    <keyword>Mapeditor</keyword>
-  </keywords>
 </component>


### PR DESCRIPTION
> **Categories and keywords**
> If there’s a launchable defined for a desktop application, categories and keywords are pulled from the desktop file. Defining them separately in the Metainfo file will override the contents of the desktop file.

Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#categories-and-keywords